### PR TITLE
#22 - Limit flyTo transitions

### DIFF
--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { LinearInterpolator, FlyToInterpolator } from 'react-map-gl';
+import { FlyToInterpolator } from 'react-map-gl';
 import WebMercatorViewport from 'viewport-mercator-project';
 import lineString from 'turf-linestring';
 import bbox from '@turf/bbox';

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { LinearInterpolator } from 'react-map-gl';
+import { LinearInterpolator, FlyToInterpolator } from 'react-map-gl';
 import WebMercatorViewport from 'viewport-mercator-project';
 import lineString from 'turf-linestring';
 import bbox from '@turf/bbox';
@@ -122,6 +122,8 @@ class Home extends Component {
         longitude,
         latitude,
         zoom,
+        transitionInterpolator: new FlyToInterpolator(),
+        transitionDuration: 500,
       },
       loopKey: loop.properties.key,
     }));
@@ -191,9 +193,7 @@ class Home extends Component {
           loops={this.state.loops}
           stops={
             this.state.loops[0] && this.state.loopStops[this.state.loopKey] // Only pass stops for the selected loop
-              ? this.state.loopStops[this.state.loopKey].map(
-                stopKey => this.state.stops[stopKey],
-              )
+              ? this.state.loopStops[this.state.loopKey].map(stopKey => this.state.stops[stopKey])
               : []
           }
           onLoopSelect={this.onLoopSelect}

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -6,11 +6,10 @@ import { fromJS } from 'immutable';
 // Component specific modules (Component-styled, etc.)
 
 // App components
-import ReactMapGL, { Marker, GeolocateControl, FlyToInterpolator } from 'react-map-gl';
+import ReactMapGL, { Marker, GeolocateControl } from 'react-map-gl';
 import StopMarker from './StopMarker';
 import ShuttleMarker from './ShuttleMarker';
 import geoJSONFeatureShape from '../utils/geoJSONFeatureShape';
-import { getLoop } from '../utils/functions';
 
 // Third-party components (buttons, icons, etc.)
 

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -1,20 +1,16 @@
 // Framework and third-party non-ui
-import React, { Component } from "react";
-import PropTypes from "prop-types";
-import { fromJS } from "immutable";
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { fromJS } from 'immutable';
 
 // Component specific modules (Component-styled, etc.)
 
 // App components
-import ReactMapGL, {
-  Marker,
-  GeolocateControl,
-  FlyToInterpolator
-} from "react-map-gl";
-import StopMarker from "./StopMarker";
-import ShuttleMarker from "./ShuttleMarker";
-import geoJSONFeatureShape from "../utils/geoJSONFeatureShape";
-import { getLoop } from "../utils/functions";
+import ReactMapGL, { Marker, GeolocateControl, FlyToInterpolator } from 'react-map-gl';
+import StopMarker from './StopMarker';
+import ShuttleMarker from './ShuttleMarker';
+import geoJSONFeatureShape from '../utils/geoJSONFeatureShape';
+import { getLoop } from '../utils/functions';
 
 // Third-party components (buttons, icons, etc.)
 
@@ -27,37 +23,37 @@ class Map extends Component {
     super(props);
 
     this.state = {
-      mapStyle: null
+      mapStyle: null,
     };
   }
 
   componentDidMount() {
     fetch(process.env.REACT_APP_MAPSTYLE_URL)
       .then(res => res.json())
-      .then(json => {
+      .then((json) => {
         const mapStyle = json;
         mapStyle.sources.loops = {
-          type: "geojson",
+          type: 'geojson',
           data: {
-            type: "FeatureCollection",
-            features: this.props.loops
-          }
+            type: 'FeatureCollection',
+            features: this.props.loops,
+          },
         };
         mapStyle.layers.push({
-          id: "loops",
-          type: "line",
-          source: "loops",
+          id: 'loops',
+          type: 'line',
+          source: 'loops',
           layout: {
-            "line-join": "round",
-            "line-cap": "round"
+            'line-join': 'round',
+            'line-cap': 'round',
           },
           paint: {
-            "line-width": 3,
-            "line-color": ["get", "color"]
-          }
+            'line-width': 3,
+            'line-color': ['get', 'color'],
+          },
         });
         this.setState({
-          mapStyle: fromJS(mapStyle)
+          mapStyle: fromJS(mapStyle),
         });
       });
   }
@@ -73,37 +69,27 @@ class Map extends Component {
           onClick={this.props.onMapClick}
           minZoom={minZoom}
           maxZoom={maxZoom}
-          transitionDuration={300}
-          transitionInterpolator={new FlyToInterpolator()}
         >
           <GeolocateControl
             style={{
-              position: "absolute",
-              left: "10px",
-              top: "10px"
+              position: 'absolute',
+              left: '10px',
+              top: '10px',
             }}
             positionOptions={{ enableHighAccuracy: true }}
             trackUserLocation
           />
-          {Object.keys(this.props.stops).map(stopKey => {
-            const [longitude, latitude] = this.props.stops[
-              stopKey
-            ].geometry.coordinates;
+          {Object.keys(this.props.stops).map((stopKey) => {
+            const [longitude, latitude] = this.props.stops[stopKey].geometry.coordinates;
             return (
               <Marker key={stopKey} longitude={longitude} latitude={latitude}>
                 <StopMarker />
               </Marker>
             );
           })}
-          {Object.keys(this.props.shuttles).map(shuttleKey => {
+          {Object.keys(this.props.shuttles).map((shuttleKey) => {
             const shuttle = this.props.shuttles[shuttleKey];
-            return (
-              <ShuttleMarker
-                shuttle={shuttle}
-                key={shuttleKey}
-                loops={this.props.loops}
-              />
-            );
+            return <ShuttleMarker shuttle={shuttle} key={shuttleKey} loops={this.props.loops} />;
           })}
         </ReactMapGL>
       </div>
@@ -114,37 +100,36 @@ class Map extends Component {
 Map.propTypes = {
   loops: PropTypes.arrayOf(geoJSONFeatureShape).isRequired,
   stops: PropTypes.shape({
-    stopKey: geoJSONFeatureShape
+    stopKey: geoJSONFeatureShape,
   }),
   shuttles: PropTypes.shape({
-    shuttleKey: geoJSONFeatureShape
+    shuttleKey: geoJSONFeatureShape,
   }),
-  mapContainerRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) })
-    .isRequired,
+  mapContainerRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }).isRequired,
   mapOptions: PropTypes.shape({
     maxZoom: PropTypes.number,
     minZoom: PropTypes.number,
     nwBound: PropTypes.shape({
       latitude: PropTypes.number,
-      longitude: PropTypes.number
+      longitude: PropTypes.number,
     }),
     seBound: PropTypes.shape({
       latitude: PropTypes.number,
-      longitude: PropTypes.number
-    })
+      longitude: PropTypes.number,
+    }),
   }),
   viewport: PropTypes.shape({
     longitude: PropTypes.number,
     latitude: PropTypes.number,
-    zoom: PropTypes.number
+    zoom: PropTypes.number,
   }).isRequired,
-  onViewportChange: PropTypes.func.isRequired
+  onViewportChange: PropTypes.func.isRequired,
 };
 
 Map.defaultProps = {
   stops: {},
   shuttles: {},
-  mapOptions: {}
+  mapOptions: {},
 };
 
 export default Map;


### PR DESCRIPTION
This PR currently removes the flyTo transition from all map interactions and applies it specifically during the onLoopSelect viewport update. This should likely be replicated in the future for any non-mouse/touch viewport updates.