### PR TITLE
Interpolate shuttle transitions

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -23,3 +23,7 @@
     transform: rotate(360deg);
   }
 }
+
+.mapboxgl-marker.shuttle-marker--not-interacting {
+  transition: top 1s linear, left 1s linear;
+}

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -23,7 +23,10 @@ class Map extends Component {
 
     this.state = {
       mapStyle: null,
+      isInteracting: false,
     };
+
+    this.onInteractionStateChange = this.onInteractionStateChange.bind(this);
   }
 
   componentDidMount() {
@@ -57,6 +60,13 @@ class Map extends Component {
       });
   }
 
+  onInteractionStateChange(interactionState) {
+    const { isPanning, isDragging, isZooming } = interactionState;
+    this.setState({
+      isInteracting: isPanning || isDragging || isZooming,
+    });
+  }
+
   render() {
     const { maxZoom, minZoom } = this.props.mapOptions;
     return (
@@ -64,6 +74,7 @@ class Map extends Component {
         <ReactMapGL
           {...this.props.viewport}
           mapStyle={this.state.mapStyle}
+          onInteractionStateChange={this.onInteractionStateChange}
           onViewportChange={this.props.onViewportChange}
           onClick={this.props.onMapClick}
           minZoom={minZoom}
@@ -88,7 +99,14 @@ class Map extends Component {
           })}
           {Object.keys(this.props.shuttles).map((shuttleKey) => {
             const shuttle = this.props.shuttles[shuttleKey];
-            return <ShuttleMarker shuttle={shuttle} key={shuttleKey} loops={this.props.loops} />;
+            return (
+              <ShuttleMarker
+                shuttle={shuttle}
+                key={shuttleKey}
+                loops={this.props.loops}
+                isInteracting={this.state.isInteracting}
+              />
+            );
           })}
         </ReactMapGL>
       </div>

--- a/src/components/ShuttleMarker.jsx
+++ b/src/components/ShuttleMarker.jsx
@@ -1,9 +1,9 @@
-import React, { Component } from "react";
-import PropTypes from "prop-types";
-import styled from "styled-components";
-import { Marker } from "react-map-gl";
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { Marker } from 'react-map-gl';
 
-import { getLoop } from "../utils/functions";
+import { getLoop } from '../utils/functions';
 
 const ShuttleMarkerContainer = styled.div`
   width: 42px;
@@ -15,8 +15,6 @@ const ShuttleMarkerContainer = styled.div`
   align-items: center;
   justify-content: center;
   transform: rotate(${props => `${props.bearing}deg`});
-  transition: left 0.5s linear;
-  transition: top 0.5s linear;
 `;
 
 const StyledShuttleMarker = styled.div`
@@ -45,6 +43,7 @@ class ShuttleMarker extends Component {
         latitude={latitude}
         captureClick
         onClick={this.onClick}
+        className={this.props.isInteracting ? '' : 'shuttle-marker--not-interacting'}
       >
         <ShuttleMarkerContainer bearing={bearing}>
           <StyledShuttleMarker loop={loop} />
@@ -54,8 +53,12 @@ class ShuttleMarker extends Component {
   }
 }
 
-ShuttleMarker.defaultProps = {};
+ShuttleMarker.defaultProps = {
+  isInteracting: false,
+};
 
-ShuttleMarker.propTypes = {};
+ShuttleMarker.propTypes = {
+  isInteracting: PropTypes.bool,
+};
 
 export default ShuttleMarker;


### PR DESCRIPTION
This PR applies CSS transitions to the `top` and `left` CSS properties that the react-map-gl library uses to absolutely position Markers on the map. This provides a smooth visual appearance instead of the once-per-second jumps across the map.
Since react-map-gl does not pass the `style` prop if specified on their `Marker` component, a CSS class is used as a workaround and class definition is added to `App.css`.
Since the transition would also apply when zooming or panning on the map, and the marker would slowly move back to its intended position, this class is only applied when an `isInteracting` prop on the ShuttleMarker is set to true which is determined and passed via an `onInteractionStateChange` event on the `Map` component.