### PR TITLE
Fade stop markers that are not on the selected loop

### DIFF
--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -40,6 +40,7 @@ class Home extends Component {
     loopStops: undefined,
     selectedLoop: '',
     selectedStop: '',
+    selectedLoopStops: [],
     selectedShuttle: '',
     viewport: {
       width: '100%',
@@ -168,8 +169,8 @@ class Home extends Component {
         transitionInterpolator: new FlyToInterpolator(),
         transitionDuration: 500,
       },
-      selectedLoop: loop,
-      selectedLoopStops: prevState.loopStops[loop.properties.key],
+      selectedLoop: loopKey,
+      selectedLoopStops: prevState.loopStops[loopKey],
       openBottomSheet: 'loop-stops',
     }));
   };
@@ -197,6 +198,7 @@ class Home extends Component {
       openBottomSheet: prevState.openBottomSheet ? '' : 'loops',
       selectedStop: '',
       selectedLoop: '',
+      selectedLoopStops: [],
       selectedShuttle: '',
     }));
   };
@@ -247,6 +249,7 @@ class Home extends Component {
           stops={this.state.stops}
           shuttles={this.state.shuttles}
           selectedStop={this.state.selectedStop}
+          selectedLoopStops={this.state.selectedLoopStops}
           updateMapDimensions={this.updateMapDimensions}
           mapOptions={this.constants.mapOptions}
           onViewportChange={this.onViewportChange}

--- a/src/components/Map/Map.jsx
+++ b/src/components/Map/Map.jsx
@@ -6,23 +6,26 @@ import { fromJS } from 'immutable';
 import CustomMapController from './CustomMapController';
 
 // App components
-import ReactMapGL, { GeolocateControl } from 'react-map-gl';
 import StopMarker from '../StopMarker';
-import ShuttleMarker from '../ShuttleMarker';
+import ShuttleMarker from './ShuttleMarker';
 
 // Third-party components (buttons, icons, etc.)
+import ReactMapGL, { GeolocateControl } from 'react-map-gl';
 
 // JSON
 
 // CSS
 
 const StopMarkerLayer = React.memo(props => Object.keys(props.stops).map((stopKey) => {
+  const stop = props.stops[stopKey];
   const selected = props.selectedStop === stopKey;
+  const disabled = props.selectedLoopStops.length > 0 && !props.selectedLoopStops.includes(stopKey);
   return (
     <StopMarker
       key={stopKey}
-      stop={props.stops[stopKey]}
+      stop={stop}
       selected={selected}
+      disabled={disabled}
       onStopSelect={props.onStopSelect}
       isInteracting={props.isInteracting}
     />
@@ -101,6 +104,7 @@ class Map extends Component {
           <StopMarkerLayer
             stops={this.props.stops}
             selectedStop={this.props.selectedStop}
+            selectedLoopStops={this.props.selectedLoopStops}
             onStopSelect={this.props.onStopSelect}
             isInteracting={this.state.isInteracting}
           />

--- a/src/components/Map/ShuttleMarker.jsx
+++ b/src/components/Map/ShuttleMarker.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Marker } from 'react-map-gl';
 import TinyColor from '@ctrl/tinycolor';
 
-import { getLoop } from '../utils/functions';
+import { getLoop } from '../../utils/functions';
 
 const ShuttleMarkerContainer = styled.div.attrs(props => ({
   style: {

--- a/src/components/StopMarker/StopMarker-styled.js
+++ b/src/components/StopMarker/StopMarker-styled.js
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+
+export const StopMarkerContainer = styled.div.attrs(props => ({
+  style: {
+    width: props.selected ? '66px' : '42px',
+    height: props.selected ? '66px' : '42px',
+  },
+}))`
+  transform: translate(-50%, -70%);
+  transition-duration: 0.1s;
+  transition-timing-function: ease-out;
+  transition-property: width, height, top, left;
+
+  svg circle,
+  svg path {
+    transition: fill 0.1s linear;
+  }
+`;

--- a/src/components/StopMarker/StopMarker.jsx
+++ b/src/components/StopMarker/StopMarker.jsx
@@ -1,27 +1,13 @@
 import React, { PureComponent } from 'react';
-import styled from 'styled-components';
 import { Marker } from 'react-map-gl';
 
-const StopMarkerContainer = styled.div.attrs(props => ({
-  style: {
-    width: props.selected ? '66px' : '42px',
-    height: props.selected ? '66px' : '42px',
-  },
-}))`
-  transform: translate(-50%, -70%);
-  transition-duration: 0.1s;
-  transition-timing-function: ease-out;
-  transition-property: width, height, top, left;
-
-  svg circle,
-  svg path {
-    transition: fill 0.1s linear;
-  }
-`;
+import { StopMarkerContainer } from './StopMarker-styled';
 
 class StopMarker extends PureComponent {
   render() {
-    const { stop, selected, onStopSelect } = this.props;
+    const {
+      stop, selected, disabled, onStopSelect,
+    } = this.props;
     const fill = selected ? '#3cd3ab' : '#33a3f4';
     const [longitude, latitude] = stop.geometry.coordinates;
     return (
@@ -30,7 +16,7 @@ class StopMarker extends PureComponent {
         latitude={latitude}
         className={`stop-marker ${selected ? 'stop-marker--selected' : ''}`}
       >
-        <StopMarkerContainer selected={selected} onClick={() => onStopSelect(stop.properties.stopKey)}>
+        <StopMarkerContainer selected={selected} onClick={() => !disabled && onStopSelect(stop.properties.stopKey)}>
           <svg
             xmlns="http://www.w3.org/2000/svg"
             fillRule="evenodd"
@@ -39,6 +25,7 @@ class StopMarker extends PureComponent {
             strokeMiterlimit="1.5"
             clipRule="evenodd"
             viewBox="0 0 93 93"
+            style={disabled ? { filter: 'opacity(0.3) saturate(0.75)' } : null}
           >
             <ellipse cx="46.08" cy="83.54" fill="url(#_Radial1)" rx="32.32" ry="8.62" />
             <circle cx="46.05" cy="80.25" r="5.34" fill={fill} />

--- a/src/components/StopMarker/index.js
+++ b/src/components/StopMarker/index.js
@@ -1,0 +1,1 @@
+export { default } from './StopMarker';


### PR DESCRIPTION
![localhost_3000_(Pixel 2 XL) (2)](https://user-images.githubusercontent.com/5069711/64313494-a72c0200-cf60-11e9-865a-872d06efb9d7.png)

Adds a `disabled` prop to StopMarker which applies a CSS `filter` against the SVG. Also disables the onClick handler so a stop outside of the currently selected loop cannot be selected.