### PR TITLE
Improve mobile sizing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4234,9 +4234,9 @@
       }
     },
     "calcite-ui-icons-react": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/calcite-ui-icons-react/-/calcite-ui-icons-react-0.7.2.tgz",
-      "integrity": "sha512-A7YBcNhZsp7bUKacSdgFDef/JwnDXv7KyDRVz0oyV0cZ+9isAPmgARLZlHLB6xdM1gQsiF4wNCtNpaHewAiogA=="
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/calcite-ui-icons-react/-/calcite-ui-icons-react-0.10.0.tgz",
+      "integrity": "sha512-bFDQX11w+oUBvtotPICifyHXmDbNwyDA4mtBS7/u0tJiaOURozl7WjZZrqKpCS3nISZ7E6OS90fOazhJtQA8pA=="
     },
     "call-me-maybe": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "ajv": "^6.10.2",
     "ajv-keywords": "^3.4.0",
     "calcite-react": "^0.40.0",
-    "calcite-ui-icons-react": "^0.7.2",
+    "calcite-ui-icons-react": "^0.10.0",
     "express-sslify": "^1.2.0",
     "firebase": "^6.3.1",
     "immutable": "^4.0.0-rc.12",

--- a/src/components/Home/Home.jsx
+++ b/src/components/Home/Home.jsx
@@ -118,7 +118,6 @@ class Home extends Component {
   };
 
   onShuttleSelect = shuttleKey => {
-    debugger;
     const [longitude, latitude] = this.state.shuttles[shuttleKey].geometry.coordinates;
     this.setState(prevState => ({
       selectedShuttle: shuttleKey,

--- a/src/components/LoopStopsBottomSheet/LoopStopsBottomSheet-styled.js
+++ b/src/components/LoopStopsBottomSheet/LoopStopsBottomSheet-styled.js
@@ -26,7 +26,7 @@ export const LoopStopsListItemLeftSide = styled.div`
 
 export const LoopStopsName = styled.span`
   font-family: ${props => props.theme.type.avenirFamily};
-  font-size: 1.3em;
+  font-size: 1.8em;
   font-weight: 600;
   align-self: flex-start;
   color: #ffffff;

--- a/src/components/LoopStopsBottomSheet/LoopStopsBottomSheet.jsx
+++ b/src/components/LoopStopsBottomSheet/LoopStopsBottomSheet.jsx
@@ -27,7 +27,7 @@ class LoopStopsBottomSheet extends PureComponent {
             return (
               <LoopStopsListItem key={stop.properties.name} tabIndex="0" onClick={() => onStopSelect(stopKey)}>
                 <LoopStopsListItemLeftSide>
-                  <NextStopIcon />
+                  <NextStopIcon width="40" height="40" />
                   <LoopStopsName color={stop.properties.color}>{stop.properties.name}</LoopStopsName>
                 </LoopStopsListItemLeftSide>
                 {/* <ETALabel number={eta} /> */}

--- a/src/components/LoopsBottomSheet/LoopsBottomSheet-styled.js
+++ b/src/components/LoopsBottomSheet/LoopsBottomSheet-styled.js
@@ -32,7 +32,7 @@ export const LoopListItem = styled.button`
   outline: none;
   border: none;
   border-top: 2px solid #f1f1f1;
-  padding: 0.85em;
+  padding: 1em;
 
   &:active {
     background-color: #f1f1f1;
@@ -53,8 +53,8 @@ export const LoopListItemRightSide = styled.div`
 `;
 
 export const LoopName = styled.span`
-  font-size: 1.3em;
-  font-weight: 600;
+  font-size: 1.8em;
+  font-weight: bold;
   align-self: flex-start;
   color: #ffffff;
   color: ${props => props.color || 'inherit'};

--- a/src/components/LoopsBottomSheet/LoopsBottomSheet.jsx
+++ b/src/components/LoopsBottomSheet/LoopsBottomSheet.jsx
@@ -4,7 +4,7 @@ import SwipeableBottomSheet from 'react-swipeable-bottom-sheet';
 import { LoopListItem, LoopListItemLeftSide, LoopListItemRightSide, LoopName } from './LoopsBottomSheet-styled';
 import { getBottomSheetBodyStyle, BottomSheetContainer, BottomSheetTitle } from '../../utils/commonElements';
 
-import OfflineIcon from 'calcite-ui-icons-react/OfflineIcon';
+import MoonIcon from 'calcite-ui-icons-react/MoonIcon';
 
 class LoopsBottomSheet extends PureComponent {
   render() {
@@ -22,7 +22,7 @@ class LoopsBottomSheet extends PureComponent {
           <BottomSheetTitle>Shuttle Loops</BottomSheetTitle>
           {loops.map(loop => {
             const noShuttlesAvailable =
-              shuttles &&
+              !shuttles ||
               Object.values(shuttles).filter(shuttle => shuttle.properties.loopKey === loop.properties.key).length ===
                 0;
             return (
@@ -30,7 +30,7 @@ class LoopsBottomSheet extends PureComponent {
                 <LoopListItemLeftSide>
                   <LoopName color={loop.properties.color}>{loop.properties.name}</LoopName>
                 </LoopListItemLeftSide>
-                <LoopListItemRightSide>{noShuttlesAvailable ? <OfflineIcon size={20} /> : null}</LoopListItemRightSide>
+                <LoopListItemRightSide>{noShuttlesAvailable ? <MoonIcon size={25} /> : null}</LoopListItemRightSide>
               </LoopListItem>
             );
           })}

--- a/src/components/LoopsBottomSheet/NextStopIcon.jsx
+++ b/src/components/LoopsBottomSheet/NextStopIcon.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { NextStopSVG } from './LoopsBottomSheet-styled';
 
 const NextStopIcon = () => (
-  <NextStopSVG viewBox="0 0 30 20">
+  <NextStopSVG>
     <path
       fillRule="evenodd"
       strokeLinejoin="round"

--- a/src/components/Map/Map-styled.js
+++ b/src/components/Map/Map-styled.js
@@ -1,14 +1,24 @@
 import styled from 'styled-components';
-import { GeolocateControl,NavigationControl } from 'react-map-gl';
+import { GeolocateControl, NavigationControl } from 'react-map-gl';
 
 export const StyledGeolocateControl = styled(GeolocateControl)`
   position: absolute;
   right: 10px;
   top: 10px;
+
+  button {
+    height: 2.4rem;
+    width: 2.4rem;
+  }
 `;
 
 export const StyledNavigationControl = styled(NavigationControl)`
   position: absolute;
   right: 10px;
-  top: 50px;
+  top: 3.6rem;
+  
+  button {
+    height: 2.4rem;
+    width: 2.4rem;
+  }
 `;

--- a/src/components/NextStopIcon/NextStopIcon-styled.js
+++ b/src/components/NextStopIcon/NextStopIcon-styled.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
 export const NextStopSVG = styled.svg`
-  height: 1em;
+  height: 1.2em;
   margin-right: 0.2em;
 `;

--- a/src/components/OverflowMenu/OverflowMenu.jsx
+++ b/src/components/OverflowMenu/OverflowMenu.jsx
@@ -16,18 +16,18 @@ import HandleVerticalIcon from 'calcite-ui-icons-react/HandleVerticalIcon';
 
 class OverflowMenu extends Component {
   state = {
-    open: false,
+    open: false
   };
 
   toggleMenu = () => {
     this.setState(prevState => ({
-      open: !prevState.open,
+      open: !prevState.open
     }));
   };
 
   closeMenu = () => {
     this.setState({
-      open: false,
+      open: false
     });
   };
 
@@ -39,10 +39,10 @@ class OverflowMenu extends Component {
           open={this.state.open}
           onRequestClose={this.closeMenu}
           targetContainerStyles={{
-            display: 'flex',
+            display: 'flex'
           }}
         >
-          <StyledMenu>
+          <StyledMenu large>
             <MenuItem onClick={() => window.open('https://intranet.bloomu.edu/documents/police/BusSchedule.pdf')}>
               Shuttle Schedule
             </MenuItem>
@@ -52,9 +52,7 @@ class OverflowMenu extends Component {
             <MenuItem disabled subtitle="WIP" onClick={() => this.props.history.push('/feedback')}>
               Feedback
             </MenuItem>
-            <MenuItem disabled subtitle="WIP" onClick={() => this.props.history.push('/issue')}>
-              Report an Issue
-            </MenuItem>
+            <MenuItem onClick={() => window.open('mailto:bloombus@huskies.bloomu.edu')}>Report an Issue</MenuItem>
             <MenuItem onClick={() => this.props.history.push('/about')}>About</MenuItem>
           </StyledMenu>
         </Popover>

--- a/src/utils/commonElements.js
+++ b/src/utils/commonElements.js
@@ -15,6 +15,7 @@ export const BottomSheetContainer = styled.div`
   justify-content: center;
   z-index: 500;
   font-family: ${props => props.theme.type.avenirFamily};
+  font-size: 1.3rem;
 
   &::after {
     width: 2rem;


### PR DESCRIPTION
Various stylistic enhancements, primarily to make buttons more clickable on a mobile device.
Also upgraded the `calcite-ui-icons-react` package to `0.10.0` to make use of newly available icons such as `Moon`. Would like to switch this to the `filled` version when that becomes available.

Before:
![bloombus herokuapp com_(Pixel 2 XL) (1)](https://user-images.githubusercontent.com/5069711/67138251-56612780-f1f5-11e9-803d-ca3165f4f4de.png)

After:
![localhost_3000_(Pixel 2 XL) (4)](https://user-images.githubusercontent.com/5069711/67138255-58c38180-f1f5-11e9-85d1-9d7492fe0494.png)
